### PR TITLE
Add rust-toolchain.toml to pin rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Frameless Runtime
 
 Run `cargo doc --open --document-private-items --no-deps`, and start hacking 🚀
+
+## Formatting
+
+If you add code and want to format it, use `cargo +nightly fmt`.
+The formatter rules are not supported in stable.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.84.1"
+targets = ["wasm32-unknown-unknown"]
+components = ["rust-src"]


### PR DESCRIPTION
Pinned it to the latest version [polkadot-sdk uses in CI](https://github.com/paritytech/polkadot-sdk/blob/f1d1d9c5c8d0effe4c60b81f6eaaa112ddc14658/.github/env#L1).
